### PR TITLE
Poetry はパッケージングをスキップして依存関係の管理のみを行うようにする.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Python のマイクロフレームワークである [Flask](https://palletsproj
 本リポジトリを利用する際は、事前に下記を実行してパッケージのインストールを行い、依存関係を解決しておいてください。
 
 ```bash
-% poetry install
+% poetry install --no-root
 ```
 
 # 起動

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["ksh-fthr <ksh.fthr0806@gmail.com>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.13"


### PR DESCRIPTION
## README の更新

コマンド例を `poetry install` 時に `--no-root` オプション付きで実行するようにした.

```bash
% poetry install --no-root
```

## pyproject.toml の更新

`[tool.poetry]` に `package-mode = false` を追加.

```toml
[tool.poetry]
name = "flask-work"
version = "0.1.0"
description = ""
authors = ["ksh-fthr <ksh.fthr0806@gmail.com>"]
readme = "README.md"
package-mode = false # ◀ 追加
```